### PR TITLE
feat: added graphql test for data model

### DIFF
--- a/tests/config.ts
+++ b/tests/config.ts
@@ -1,0 +1,3 @@
+export const host: string = "http://localhost:8080";
+export const schema: string = "test";
+export const graphqlApi = `${host}/${schema}/graphql`;

--- a/tests/config.ts
+++ b/tests/config.ts
@@ -1,3 +1,3 @@
 export const host: string = "http://localhost:8080";
 export const schema: string = "test";
-export const graphqlApi = `${host}/${schema}/graphql`;
+export const graphqlApi: string = `${host}/${schema}/graphql`;

--- a/tests/graphql/query_individuals.spec.ts
+++ b/tests/graphql/query_individuals.spec.ts
@@ -1,0 +1,123 @@
+/**
+ * @name query_individuals
+ * @description
+ * Retrieve metadata from the graphql to ensure all metadata the individual to
+ * files hierarchy still works. We want to test for the following conditions:
+ *
+ * 1. The number of individuals in the demo dataset has not changed and can be retrieved
+ * 2. Samples, files, and consent can still be retrieved via materials
+ * 3. Experiments can still be accessed through samples
+ * 4. Files are accessible in materials and experiments (also through samples)
+ * 
+ * To run this test, follow these steps:
+ * 
+ * 1. Open the tests/onfig.ts file and set the host and schema. It is recommend
+ *    to run these tests against the dev branch (i.e., localhost). Alternatively,
+ *    you run the tests against a preview server; make sure the schema is public.
+ * 2. Run the test: `yarn vitest tests/graphql/query_individuals.spec.ts
+ * 3. If any of the tests fail, please resolve the issues.
+ *      a. Check to see if your changes did not break the model hierarchy
+ *      b. Check for changes in the model (i.e., column names, table names)
+ *      c. If there were breaking changes, make sure these are done with
+ *         good intent, and then update these tests.
+ */
+
+import { expect, test, describe } from "vitest";
+import { graphqlApi } from "../config";
+
+interface QueryResponse {
+  data: {
+    Individuals: Record<string, any>[];
+  };
+}
+
+type Individual = Record<string, any>;
+
+const query = `query {
+    Individuals(filter:{includedInResources: { id: { equals: "EGAD00001008392" }}}) {
+    id
+    materials {
+      id
+      mg_tableclass
+
+      usedInExperiments {
+        id
+        mg_tableclass
+        outputFiles {
+            id
+        }
+      }
+    }
+  }
+}`;
+
+let individualsData: Individual[];
+
+describe("GraphQL: Individuals", () => {
+  test.beforeAll(async () => {
+    const response = await fetch(graphqlApi, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ query: query }),
+    });
+    const data = (await response.json()) as QueryResponse;
+    individualsData = data.data.Individuals;
+  });
+
+  test("Individuals: There are 18 individuals in the example dataset", () => {
+    const pids = individualsData.map((row) => row.id);
+    expect(pids.length).toEqual(18);
+  });
+
+  test("Materials: The first index has 4 samples, 25 files, and 1 consent", () => {
+    const proband = individualsData.filter((row) => row.id === "Case1C");
+    const materials = proband[0].materials;
+    const samples = materials.filter((row: Record<string, any>) =>
+      row.mg_tableclass.includes(".Samples")
+    );
+    const files = materials.filter((row: Record<string, any>) =>
+      row.mg_tableclass.includes(".Files")
+    );
+    const consent = materials.filter((row: Record<string, any>) =>
+      row.mg_tableclass.includes(".Individual consent")
+    );
+
+    expect(consent.length).toEqual(1);
+    expect(samples.length).toEqual(4);
+    expect(files.length).toEqual(25);
+  });
+
+  test("Experiments: records are accessible through samples", () => {
+    const experiments = individualsData
+      .filter((row) => row.id === "Case1C")[0]
+      .materials.filter((row: Record<string, any>) =>
+        row.mg_tableclass.includes(".Samples")
+      )
+      .map((row: Record<string, any>) => [
+        ...row.usedInExperiments.map((row: Record<string, any>) => row.id),
+      ]);
+    expect(experiments.length).toEqual(4);
+  });
+
+  test("Files: data is accessible through samples and experiments", () => {
+    const files = individualsData
+      .filter((row) => row.id === "Case1C")[0]
+      .materials.filter(
+        (row: Record<string, any>) =>
+          row.mg_tableclass.includes(".Samples") && row.usedInExperiments
+      )
+      .filter((row: Record<string, any>) => row.usedInExperiments)
+      .reduce((acc: number, item: Record<string, any>) => {
+        const hasOuputFiles = item.usedInExperiments.find(
+          (row: Record<string, any>) => row.outputFiles
+        );
+        if (hasOuputFiles) {
+          acc += 1;
+        }
+        return acc;
+      }, 0);
+    expect(files).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Objective

This PR adds the first unit test that will be used to validate the model and to ensure everything is working properly, including the model hierarchy. It is expected that these tests should be run against any new branch; this can be done locally (using gradle) or a preview server. Either way, make sure the host and schema is defined in the `tests/config.ts` file. 

## Steps

- [x] Create a query that retrieves all individuals and all materials associated with them. This also means experiments will be included.
- [x] Create tests that evaluate the output to make sure all data is linked and can be accessed
- [x] Add a configuration file to allow these tests to be run against a local or remote server


## How to test

> [!NOTE]
> This PR requires the rd3-samples-experiments-split branch. Make sure you use that version of EMX2 for testing.

1. Checkout this branch locally
2. Start EMX2 locally using gradle. Make sure an RD3 schema is available to test. 
3. If host or schema has changed, update the `tests/config.ts` file.
4. Run the graphql test: `yarn vitest tests/graphql/query_individuals.spec.ts`
5. All tests should pass
